### PR TITLE
Add support for Python 3 and Django 1.5+

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 django_transfer.egg-info/*
 *.pyc
+build/*
+dist/*

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+django_transfer.egg-info/*
+*.pyc

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,16 @@ env:
   - DJANGO=1.5
   - DJANGO=1.6
   - DJANGO=1.7
+matrix:
+  exclude:
+    - python: "3.3"
+      env: DJANGO=1.3
+    - python: "3.3"
+      env: DJANGO=1.4
+    - python: "3.4"
+      env: DJANGO=1.3
+    - python: "3.4"
+      env: DJANGO=1.4
 install:
   - pip install --timeout=30 -q Django==$DJANGO
   - pip install --timeout=30 pep8

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,8 @@ env:
   - DJANGO=1.7
 matrix:
   exclude:
+    - python: "2.6"
+      env: DJANGO=1.7
     - python: "3.3"
       env: DJANGO=1.3
     - python: "3.3"

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,14 @@ language: python
 python:
   - "2.6"
   - "2.7"
+  - "3.3"
+  - "3.4"
 env:
   - DJANGO=1.3
   - DJANGO=1.4
+  - DJANGO=1.5
+  - DJANGO=1.6
+  - DJANGO=1.7
 install:
   - pip install --timeout=30 -q Django==$DJANGO --use-mirrors
   - pip install --timeout=30 pep8 --use-mirrors

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,10 +11,10 @@ env:
   - DJANGO=1.6
   - DJANGO=1.7
 install:
-  - pip install --timeout=30 -q Django==$DJANGO --use-mirrors
-  - pip install --timeout=30 pep8 --use-mirrors
-  - pip install --timeout=30 https://github.com/dcramer/pyflakes/tarball/master
-  - pip install --timeout=30 -q -e . --use-mirrors
+  - pip install --timeout=30 -q Django==$DJANGO
+  - pip install --timeout=30 pep8
+  - pip install --timeout=30 pyflakes
+  - pip install --timeout=30 -q -e .
 before_script:
   - make verify
 script:

--- a/django_transfer/__init__.py
+++ b/django_transfer/__init__.py
@@ -1,11 +1,13 @@
+from __future__ import unicode_literals
+
 import os
 import shutil
 import mimetypes
 
-from urllib import quote
+from six.moves.urllib.parse import quote
 
 from django.conf import settings
-from django.http import HttpResponse
+from django.http import StreamingHttpResponse
 from django.core.files.uploadedfile import UploadedFile
 from django.core.exceptions import ImproperlyConfigured
 
@@ -63,7 +65,7 @@ def get_header_value(path):
     return quote(path.encode('utf-8'))
 
 
-class TransferHttpResponse(HttpResponse):
+class TransferHttpResponse(StreamingHttpResponse):
     def __init__(self, path, mimetype=None, status=None,
                  content_type=None):
         if mimetype:
@@ -76,7 +78,7 @@ class TransferHttpResponse(HttpResponse):
             content = ''
         else:
             # Fall back to sending file contents via Django HttpResponse.
-            content = file(path, 'r')
+            content = open(path, 'rb')
         super(TransferHttpResponse, self).__init__(content, status=status,
                                                    content_type=content_type)
         if enabled:
@@ -87,7 +89,7 @@ class TransferHttpResponse(HttpResponse):
 class ProxyUploadedFile(UploadedFile):
     def __init__(self, path, name, content_type, size):
         self.path = path
-        super(ProxyUploadedFile, self).__init__(file(path, 'r'), name, content_type, size)
+        super(ProxyUploadedFile, self).__init__(open(path, 'rb'), name, content_type, size)
 
     def move(self, dst):
         "Closes then moves the file to dst."

--- a/django_transfer/__init__.py
+++ b/django_transfer/__init__.py
@@ -7,7 +7,10 @@ import mimetypes
 from six.moves.urllib.parse import quote
 
 from django.conf import settings
-from django.http import StreamingHttpResponse
+try:
+    from django.http import StreamingHttpResponse
+except:
+    from django.http import HttpResponse as StreamingHttpResponse
 from django.core.files.uploadedfile import UploadedFile
 from django.core.exceptions import ImproperlyConfigured
 

--- a/django_transfer/settings.py
+++ b/django_transfer/settings.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 # Django settings for django_transfer project.
 
 DEBUG = True

--- a/django_transfer/tests.py
+++ b/django_transfer/tests.py
@@ -141,7 +141,8 @@ class NginxTestCase(DownloadTestCase, UploadTestCase, ServerTestCase):
         # Make sure the correct header is returned.
         self.assertIn(self.header_name, r)
         # Ensure no data is returned.
-        self.assertEqual(len(r.content), 0)
+        content_len = sum(len(chunk) for chunk in r.streaming_content)
+        self.assertEqual(content_len, 0)
         # Nginx does not deal with absolute paths. Verify the mapping was done
         # properly.
         self.assertTrue(r[self.header_name].startswith('/downloads'))

--- a/django_transfer/urls.py
+++ b/django_transfer/urls.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 try:
     from django.conf.urls import patterns, url
 except ImportError:

--- a/django_transfer/views.py
+++ b/django_transfer/views.py
@@ -1,20 +1,20 @@
+from __future__ import unicode_literals
+
 import os
 import json
 import tempfile
 
 from django.http import HttpResponse
+import six
 
 from django_transfer import TransferHttpResponse
 
 
 def make_tempfile():
     "Create a temp file, write our PID into it."
-    fd, t = tempfile.mkstemp()
-    try:
-        os.write(fd, str(os.getpid()))
-    finally:
-        os.close(fd)
-    return t
+    with tempfile.NamedTemporaryFile(mode='w', delete=False) as temp:
+        temp.write(six.text_type(os.getpid()))
+        return temp.name
 
 
 def download(request):
@@ -33,7 +33,7 @@ def upload(request):
                 'path': file.name,
                 'size': file.size,
                 'content-type': file.content_type,
-                'data': file.read(),
+                'data': file.read().decode(),
             }
         for name, value in request.POST.items():
             fields[name] = value

--- a/django_transfer/wsgi.py
+++ b/django_transfer/wsgi.py
@@ -13,6 +13,8 @@ middleware here, or combine a Django application with an application of another
 framework.
 
 """
+from __future__ import unicode_literals
+
 import os
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "django_transfer.settings")

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[bdist_wheel]
+universal = 1

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,9 @@ setup(
     maintainer_email = 'btimby@gmail.com',
     url = 'http://github.com/smartfile/' + name + '/',
     license = 'MIT',
-    requires = [],
+    requires = [
+        "six>=1.9.0",
+    ],
     packages = [
         "django_transfer",
     ],

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 #!/bin/env python
 
 import os
-from distutils.core import setup
+from setuptools import setup
 
 name = 'django-transfer'
 version = '0.2'

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,8 @@ version = '0.2'
 release = '2'
 versrel = version + '-' + release
 readme = os.path.join(os.path.dirname(__file__), 'README.rst')
-long_description = file(readme).read()
+with open(readme) as readme_file:
+    long_description = readme_file.read()
 
 setup(
     name = name,

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
     maintainer_email = 'btimby@gmail.com',
     url = 'http://github.com/smartfile/' + name + '/',
     license = 'MIT',
-    requires = [
+    install_requires = [
         "six>=1.9.0",
     ],
     packages = [
@@ -32,7 +32,8 @@ setup(
           'Development Status :: 4 - Beta',
           'Intended Audience :: Developers',
           'Operating System :: OS Independent',
-          'Programming Language :: Python',
+          'Programming Language :: Python :: 2',
+          'Programming Language :: Python :: 3',
           'Topic :: Software Development :: Libraries :: Python Modules',
     ),
 )


### PR DESCRIPTION
I need to use django-transfer in a Python 3, Django 1.7 project, so I made some tweaks to get it to work under Python 2 and 3 and newer version of Django.