### PR TITLE
Allow enabling transfer even in DEBUG

### DIFF
--- a/django_transfer/__init__.py
+++ b/django_transfer/__init__.py
@@ -45,7 +45,7 @@ def get_header_name():
 def is_enabled():
     if not hasattr(settings, 'ENABLE_TRANSFER'):
         if settings.DEBUG:
-            return false
+            return False
 
     if getattr(settings, 'TRANSFER_SERVER', None) is None:
         return False

--- a/django_transfer/__init__.py
+++ b/django_transfer/__init__.py
@@ -43,10 +43,13 @@ def get_header_name():
 
 
 def is_enabled():
-    if settings.DEBUG:
-        return False
+    if not hasattr(settings, 'ENABLE_TRANSFER'):
+        if settings.DEBUG:
+            return false
+
     if getattr(settings, 'TRANSFER_SERVER', None) is None:
         return False
+
     return True
 
 


### PR DESCRIPTION
There are cases where nginx could be running and DEBUG would still be
True, in some of those cases we may still want to enable django transfer