### PR TITLE
Fix bug.

### DIFF
--- a/django_transfer/__init__.py
+++ b/django_transfer/__init__.py
@@ -158,7 +158,7 @@ class TransferMiddleware(MiddlewareMixin):
                 # Iterating over possible multiple files
                 for i, (name, temp) in fields:
                     content_type = content_types[i] if i in content_types else mimetypes.guess_type(name)[0]
-                    size = sizes[i] if i in sizes else os.path.getsize(temp)
+                    size = int(sizes[i]) if i in sizes else os.path.getsize(temp)
                     data.append(ProxyUploadedFile(temp, name, content_type, size))
                 # Now add a new UploadedFile object so that the web application
                 # can handle these "files" that were uploaded in the same

--- a/django_transfer/__init__.py
+++ b/django_transfer/__init__.py
@@ -149,11 +149,11 @@ class TransferMiddleware(MiddlewareMixin):
                 # determine the value from the temporary file.
                 try:
                     content_types = dict(enumerate(request.POST.pop('%s[content_type]' % field)))
-                except (KeyError, ValueError):
+                except KeyError:
                     content_types = {}
                 try:
-                    sizes = dict((request.POST.pop('%s[size]' % field)))
-                except (KeyError, ValueError):
+                    sizes = dict(enumerate(request.POST.pop('%s[size]' % field)))
+                except KeyError:
                     sizes = {}
                 # Iterating over possible multiple files
                 for i, (name, temp) in fields:


### PR DESCRIPTION
If the `field_name[size]` field is provided, then an exception is thrown when trying to utilize it. This causes the size to be calculated from the temp file instead.

With this change, the provided value will be used.