### PR TITLE
Remove Python 3.3 testing.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 python:
   - "2.7"
-  - "3.3"
   - "3.4"
   - "3.5"
   - "3.6"
@@ -16,14 +15,6 @@ env:
   - DJANGO=1.11
 matrix:
   exclude:
-    - python: "3.3"
-      env: DJANGO=1.4
-    - python: "3.3"
-      env: DJANGO=1.9
-    - python: "3.3"
-      env: DJANGO=1.10
-    - python: "3.3"
-      env: DJANGO=1.11
     - python: "3.4"
       env: DJANGO=1.4
     - python: "3.5"


### PR DESCRIPTION
Python 3.3 is not available in TravisCI by default, it is old enough to stop testing it.